### PR TITLE
.net core 2.0以后版本已经提供smtp

### DIFF
--- a/ABP框架中文文档/2.8ABP公共结构-邮件发送.md
+++ b/ABP框架中文文档/2.8ABP公共结构-邮件发送.md
@@ -36,6 +36,8 @@ public class TaskManager : IDomainService
 
 我们只是简单的[注入](2.1ABP公共结构-依赖注入.md) **IEmailSender** 接口以及使用了 **Send** 方法。Send方法有一些重载方法。它能够获取一个MailMessage对象(对于.net core它是无效的，因为.net core没有这些发送邮件的功能类：SmtpClient和MailMessage)。
 
+# 注意：.net core 2.0及以后版本，已经提供System.Net.Mail.SmtpClient，经测试可以成功发送邮件，MailKit不再是必须。
+
 #### ISmtpEmailSender
 
 有一个 **ISmtpEmailSender** 的接口，该接口扩展自 **IEmailSender**，在该接口中有一个 **BuildClient** 方法，可以用直接使用该方法来创建一个 **SmtpClient** 对象(对于.net core它是无效的，因为.net core没有这些发送邮件的功能类：SmtpClient和MailMessage)。在大多数情况下使用 **IEmailSender** 发送邮件，这已经足够了。


### PR DESCRIPTION
.net core 2.0以后版本已经提供smtp，经过测试可以成功发送邮件，不再需要依赖MailKit